### PR TITLE
修改配置了escape不生效的bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 coverage
 node_modules
 npm-debug.log
+.idea

--- a/lib/compile/compiler.js
+++ b/lib/compile/compiler.js
@@ -242,7 +242,7 @@ var Compiler = function () {
         var code = script.code;
 
         if (output) {
-            if (escape === false || output === tplTokenizer.TYPE_RAW) {
+            if (this.options.escape === false || output === tplTokenizer.TYPE_RAW) {
                 code = OUT + '+=' + script.code;
             } else {
                 code = OUT + '+=' + ESCAPE + '(' + script.code + ')';


### PR DESCRIPTION
通过查看art-template-loader源码发现，在`art-template/lib/compile/compiler.js`文件中，第244行：
```javascript
if (escape === false || output === tplTokenizer.TYPE_RAW) {
    code = OUT + '+=' + script.code;
} else {
    code = OUT + '+=' + ESCAPE + '(' + script.code + ')';
}
```

上下文并没有对变量`escape`进行定义，默认取值为内置的被废弃的~~escape~~方法

art-template版本号:4.10.2